### PR TITLE
Move the disabled shim so it works in firefox

### DIFF
--- a/dist/FancyButton.css
+++ b/dist/FancyButton.css
@@ -7,7 +7,8 @@
   width: 100%;
   height: 100%;
   top: 0;
-  left: 0; }
+  left: 0;
+  cursor: pointer; }
 
 .fancy-button__label-transparent {
   color: transparent; }

--- a/dist/FancyButton.css
+++ b/dist/FancyButton.css
@@ -1,4 +1,4 @@
-.fancy-button {
+.fancy-button-wrapper {
   position: relative; }
 
 .fancy-button__disabled {

--- a/dist/FancyButton.js
+++ b/dist/FancyButton.js
@@ -52,31 +52,35 @@ exports.default = _react2.default.createClass({
     onDisabledClick && onDisabledClick();
   },
   render: function render() {
-    var _props = this.props;
-    var type = _props.type;
-    var trigger = _props.trigger;
-    var disabled = _props.disabled;
-    var onClick = _props.onClick;
-    var classes = _props.classes;
-    var label = _props.label;
+    var _props = this.props,
+        type = _props.type,
+        trigger = _props.trigger,
+        disabled = _props.disabled,
+        onClick = _props.onClick,
+        classes = _props.classes,
+        label = _props.label;
 
     var opts = {
       color: '#fff'
     };
 
     return _react2.default.createElement(
-      'button',
-      { ref: 'fancyButton',
-        type: type,
-        className: (0, _classnames2.default)("fancy-button", classes),
-        disabled: disabled,
-        onClick: onClick },
+      'div',
+      { ref: 'fancyButtonWrapper', className: 'fancy-button-wrapper' },
       disabled ? _react2.default.createElement('div', { ref: 'disabledButtonShim', className: 'fancy-button__disabled', onClick: this.onDisabledClick }) : null,
-      trigger ? _react2.default.createElement(_Spinner2.default, { opts: opts }) : null,
       _react2.default.createElement(
-        'span',
-        { className: (0, _classnames2.default)({ 'fancy-button__label-transparent': trigger }) },
-        label
+        'button',
+        { ref: 'fancyButton',
+          type: type,
+          className: (0, _classnames2.default)("fancy-button", classes),
+          disabled: disabled,
+          onClick: onClick },
+        trigger ? _react2.default.createElement(_Spinner2.default, { opts: opts }) : null,
+        _react2.default.createElement(
+          'span',
+          { className: (0, _classnames2.default)({ 'fancy-button__label-transparent': trigger }) },
+          label
+        )
       )
     );
   }

--- a/dist/FancyButton.scss
+++ b/dist/FancyButton.scss
@@ -9,6 +9,7 @@
   height: 100%;
   top: 0;
   left: 0;
+  cursor: pointer;
 }
 
 .fancy-button__label-transparent {

--- a/dist/FancyButton.scss
+++ b/dist/FancyButton.scss
@@ -1,4 +1,4 @@
-.fancy-button {
+.fancy-button-wrapper {
   position: relative;
 }
 

--- a/package.json
+++ b/package.json
@@ -41,11 +41,12 @@
     "mocha": "^2.5.3",
     "node-sass": "^3.4.2",
     "phantomjs": "^1.9.19",
-    "react": "^0.14.8",
+    "react": "^15.4.2",
     "react-addons-test-utils": "^15.1.0",
-    "react-dom": "^0.14.8",
+    "react-dom": "^15.4.2",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
-    "watchify": "^3.7.0"
+    "watchify": "^3.7.0",
+    "webpack": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fancy-button",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A button with a spinner that is triggered by a boolean",
   "main": "./dist/FancyButton.js",
   "repository": {

--- a/src/FancyButton.jsx
+++ b/src/FancyButton.jsx
@@ -52,16 +52,18 @@ export default React.createClass({
       color: '#fff'
     }
 
-    return <button ref="fancyButton"
-      type={type}
-      className={classnames("fancy-button", classes)}
-      disabled={disabled}
-      onClick={onClick}>
+    return <div ref="fancyButtonWrapper" className="fancy-button-wrapper">
       { disabled ? <div ref='disabledButtonShim' className="fancy-button__disabled" onClick={this.onDisabledClick}></div> : null }
-      { trigger ? <Spinner opts={opts} /> : null }
-      <span className={classnames({'fancy-button__label-transparent': trigger})}>
-        {label}
-      </span>
-    </button>
+      <button ref="fancyButton"
+        type={type}
+        className={classnames("fancy-button", classes)}
+        disabled={disabled}
+        onClick={onClick}>
+        { trigger ? <Spinner opts={opts} /> : null }
+        <span className={classnames({'fancy-button__label-transparent': trigger})}>
+          {label}
+        </span>
+      </button>
+    </div>
   }
 });

--- a/src/main.scss
+++ b/src/main.scss
@@ -9,6 +9,7 @@
   height: 100%;
   top: 0;
   left: 0;
+  cursor: pointer;
 }
 
 .fancy-button__label-transparent {

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,4 +1,4 @@
-.fancy-button {
+.fancy-button-wrapper {
   position: relative;
 }
 

--- a/test/FancyButton.spec.js
+++ b/test/FancyButton.spec.js
@@ -46,8 +46,9 @@ context('FancyButton', () => {
     it('should have disabled attr when disabled and have disabled button shim', () => {
       const component = createComponent({ disabled: true });
       const button = findDOMNode(component.refs.fancyButton);
+      const wrapper = findDOMNode(component.refs.fancyButtonWrapper);
       expect(button.hasAttribute('disabled')).to.be.true;
-      expect(button.querySelector('.fancy-button__disabled')).to.exist;
+      expect(wrapper.querySelector('.fancy-button__disabled')).to.exist;
     });
 
     it('should call onDisabledClick when disabled and user clicks', () => {


### PR DESCRIPTION
In Firefox the problem is that when the button is disabled the `onDisabledClick` method is not called.

In Firefox since the button has the `disabled` property the events doesn't bubble.

The fix is to remove the shim from inside the `button` and make it a button's sibling  and wrap all of them in a `relative` positioned div.